### PR TITLE
Update libraries + Chrome 124 compatibility + fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,13 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>
                 <configuration>
-                    <mainClass>MainKt</mainClass>
+                    <mainClass>it.auties.analyzer.MainKt</mainClass>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
@@ -64,17 +65,22 @@
         <dependency>
             <groupId>com.github.auties00</groupId>
             <artifactId>cobalt</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.17.0</version>
+            <version>4.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v124</artifactId>
+            <version>4.20.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.3.2</version>
+            <version>5.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/crypto.kt
+++ b/src/main/kotlin/crypto.kt
@@ -3,8 +3,8 @@ package it.auties.analyzer
 import it.auties.whatsapp.binary.BinaryDecoder
 import it.auties.whatsapp.crypto.AesGcm
 import it.auties.whatsapp.model.node.Node
-import org.openqa.selenium.devtools.v121.network.model.WebSocketFrameReceived
-import org.openqa.selenium.devtools.v121.network.model.WebSocketFrameSent
+import org.openqa.selenium.devtools.v124.network.model.WebSocketFrameReceived
+import org.openqa.selenium.devtools.v124.network.model.WebSocketFrameSent
 import java.util.*
 import kotlin.math.max
 

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -1,7 +1,7 @@
 package it.auties.analyzer
 
-import org.openqa.selenium.devtools.v121.debugger.Debugger
-import org.openqa.selenium.devtools.v121.network.Network
+import org.openqa.selenium.devtools.v124.debugger.Debugger
+import org.openqa.selenium.devtools.v124.network.Network
 import java.util.Optional.empty
 
 val whatsappKeys: Keys = Keys()

--- a/src/main/kotlin/remote_object.kt
+++ b/src/main/kotlin/remote_object.kt
@@ -1,12 +1,12 @@
 package it.auties.analyzer
 
 import org.openqa.selenium.devtools.DevTools
-import org.openqa.selenium.devtools.v121.runtime.Runtime
-import org.openqa.selenium.devtools.v121.debugger.model.CallFrame
-import org.openqa.selenium.devtools.v121.debugger.model.Scope
-import org.openqa.selenium.devtools.v121.runtime.model.PropertyDescriptor
-import org.openqa.selenium.devtools.v121.runtime.model.RemoteObject
-import org.openqa.selenium.devtools.v121.runtime.model.RemoteObjectId
+import org.openqa.selenium.devtools.v124.runtime.Runtime
+import org.openqa.selenium.devtools.v124.debugger.model.CallFrame
+import org.openqa.selenium.devtools.v124.debugger.model.Scope
+import org.openqa.selenium.devtools.v124.runtime.model.PropertyDescriptor
+import org.openqa.selenium.devtools.v124.runtime.model.RemoteObject
+import org.openqa.selenium.devtools.v124.runtime.model.RemoteObjectId
 import java.util.*
 
 fun getKeypairObjectId(frame: CallFrame): RemoteObjectId = frame.scopeChain

--- a/src/main/kotlin/source_script.kt
+++ b/src/main/kotlin/source_script.kt
@@ -1,10 +1,10 @@
 package it.auties.analyzer
 
 import org.openqa.selenium.devtools.DevTools
-import org.openqa.selenium.devtools.v121.debugger.Debugger
-import org.openqa.selenium.devtools.v121.debugger.model.Location
-import org.openqa.selenium.devtools.v121.debugger.model.Paused
-import org.openqa.selenium.devtools.v121.debugger.model.ScriptParsed
+import org.openqa.selenium.devtools.v124.debugger.Debugger
+import org.openqa.selenium.devtools.v124.debugger.model.Location
+import org.openqa.selenium.devtools.v124.debugger.model.Paused
+import org.openqa.selenium.devtools.v124.debugger.model.ScriptParsed
 import java.util.Optional.empty
 import java.util.Optional.of
 
@@ -32,7 +32,7 @@ private fun createBreakpoint(
 fun onBreakpointTriggered(tools: DevTools, paused: Paused) {
     val frame = paused.callFrames.first()
     val local = getKeypairObjectId(frame)
-    val key = getKeyValue("e", local, tools)!!
+    val key = getKeyValue("a", local, tools)!!
     whatsappKeys.writeIv.set(0)
     whatsappKeys.readIv.set(0)
     println("Adding key: $key")


### PR DESCRIPTION
- Update libraries to latest versions
- Compatible with latest Chrome 124
- Fix code to get decryption keys on latest WA Web 2.3000.xxxxxxxxxx

If you get the error 
```
SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114
```
or something similar, try erasing the selenium webdriver cache located at `%USERPROFILE%\.cache\selenium\chromedriver`. https://github.com/bonigarcia/webdrivermanager/issues/1282#issuecomment-2090825172